### PR TITLE
Upgrade upload-artifact action

### DIFF
--- a/.github/workflows/cifuzz.yaml
+++ b/.github/workflows/cifuzz.yaml
@@ -22,7 +22,7 @@ jobs:
        dry-run: false
        sanitizer: ${{ matrix.sanitizer }}
    - name: Upload Crash
-     uses: actions/upload-artifact@v1
+     uses: actions/upload-artifact@v4
      if: failure()
      with:
        name: ${{ matrix.sanitizer }}-artifacts


### PR DESCRIPTION
action/upload-artifact@v1 has been deprecated for a while. It seems like GitHub Actions will now cancel workflows if it is still using v1 of the action. This upgrades to the latest v4 of the action.

See https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/ for details.

Testing this for CI in our fork before PR'ing upstream